### PR TITLE
Improve PR template and branch naming convention

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,10 @@
+# New creature submission
+
+## Student information
+
+- **Your name:**
+- [ ] I am a student in Prof. Teeters' JavaScript class
+
 ## Creature information
 
 - **Creature name:**

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -128,7 +128,7 @@ Refresh your browser — your creature should appear in the gallery!
 1. Create a branch for your work:
 
    ```bash
-   git checkout -b add-creature-YOURID
+   git checkout -b add-cow-USERNAME
    ```
 
 2. Stage your files:
@@ -145,7 +145,7 @@ Refresh your browser — your creature should appear in the gallery!
 
 4. Push to your fork:
    ```bash
-   git push -u origin add-creature-YOURID
+   git push -u origin add-cow-USERNAME
    ```
 
 ---

--- a/docs/guides/fork-workflow.md
+++ b/docs/guides/fork-workflow.md
@@ -58,15 +58,20 @@ git remote -v
 
 ## Step 3: Create a branch
 
-Never work directly on `main`. Create a feature branch:
+Never work directly on `main`. Create a feature branch using your GitHub username:
 
 ```bash
-git checkout -b add-creature-YOURID
+git checkout -b add-cow-USERNAME
 ```
 
-Branch naming conventions:
+Replace `USERNAME` with your actual GitHub username. For example, if your username is `jsmith`:
 
-- `add-creature-a3f8c1` — Adding a new creature
+```bash
+git checkout -b add-cow-jsmith
+```
+
+Other branch naming conventions:
+
 - `fix-typo-readme` — Fixing something
 - `update-docs` — Documentation changes
 
@@ -102,7 +107,7 @@ Tips for commit messages:
 Push your branch to your fork (origin):
 
 ```bash
-git push -u origin add-creature-YOURID
+git push -u origin add-cow-USERNAME
 ```
 
 The `-u` flag sets up tracking so future pushes are simpler.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -286,7 +286,7 @@ git remote set-url origin https://github.com/YOUR-USERNAME/cattlelog.git
 
 ```bash
 git checkout main
-git checkout -b add-creature-YOURID
+git checkout -b add-cow-USERNAME
 ```
 
 ### "Changes not staged for commit"


### PR DESCRIPTION
## Summary

- Add student identification section to PR template (name + class checkbox)
- Change branch naming from `add-creature-YOURID` to `add-cow-USERNAME`
- Updated docs: INSTRUCTIONS.md, fork-workflow.md, troubleshooting.md

## Rationale

Students know their GitHub username before starting work, but don't have their creature ID until step 2. Using username also helps identify who submitted the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)