### PR TITLE
Add AI guide to README, specify branch naming in checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ New to the project? Start here:
 
 - **[Making ASCII art](docs/guides/making-cows.md)** — Create creatures (hand-drawn, web search, AI)
 - **[Fork workflow](docs/guides/fork-workflow.md)** — Git fork, clone, branch, PR process
+- **[Working with AI assistants](docs/guides/ai-assistants.md)** — Customize Copilot for this project
 - **[Troubleshooting](docs/guides/troubleshooting.md)** — Fix common problems
 
 ### Tutorials (optional)

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -40,7 +40,7 @@ Use this checklist to verify your work before submitting. Every item should be c
 
 ## Git workflow
 
-- [ ] Created a feature branch (not committing to main)
+- [ ] Created a feature branch named `add-cow-USERNAME` (your GitHub username)
 - [ ] Committed your changes with a descriptive message
 - [ ] Pushed your branch to your fork
 


### PR DESCRIPTION
## Summary

- Add AI assistants guide link to README guides section
- Specify `add-cow-USERNAME` branch naming in CHECKLIST.md

Small consistency updates to reference the new AI guide and clarify branch naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)